### PR TITLE
Added bower.json support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,19 @@
+{
+  "name": "Kernel.js",
+  "homepage": "https://github.com/alindsay55661/Kernel.js",
+  "authors": [
+    "(Alan Lindsay <alan@enleap.com>)"
+  ],
+  "description": "Kernel.js is an ultra lightweight (~4k) architecture for building scalable javascript applications.",
+  "main": "kernel.js",
+  "ignore": [
+    "docs",
+    "examples",
+    "hub-extensions",
+    "lib"
+  ],
+  "moduleType": [
+    "globals"
+  ],
+  "license": "MIT"
+}

--- a/kernel.js
+++ b/kernel.js
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2012 Alan Lindsay - version 2.7.5
+ Copyright (c) 2012 Alan Lindsay - version 2.7.6
 
  Permission is hereby granted, free of charge, to any person obtaining
  a copy of this software and associated documentation files (the
@@ -550,7 +550,7 @@
     onStop: function(instance) {
       instance.kill();
     },
-    version: '2.7.5',
+    version: '2.7.6',
     _internals: {
       PRIVATE: 'FOR DEBUGGING ONLY',
       type: 'Kernel',

--- a/kernel.js
+++ b/kernel.js
@@ -538,10 +538,8 @@
       for (key in listeners) {
 
         // Cycle through each type
-        for (i=0,size=listeners[key].length; i<size; i+=1) {
-
+        for (i=listeners[key].length-1; i>=0; i-=1) {
           listener = listeners[key][i];
-
           if (listener.id === id) listeners[key].splice(i, 1);
         }
       }


### PR DESCRIPTION
This pull request resolves #6 .

To test or use this right now:
bower install git://github.com/philipbjorge/Kernel.js.git#2.7.5 --save

To integrate and maintain this change, you'll have to do the following:
1. Accept the pull request and tag it with 2.7.5
2. bower register Kernel.js git://github.com/alindsay55661/Kernel.js.git
3. Every time you bump up kernel's version, add a tag to that commit with the version number.
